### PR TITLE
Bug/memory management

### DIFF
--- a/common.h
+++ b/common.h
@@ -36,6 +36,7 @@
 
 
 #define memalloc	PyMem_Malloc
+#define memcalloc	PyMem_Calloc
 #define memfree		PyMem_Free
 #define memrealloc	PyMem_Realloc
 
@@ -53,7 +54,6 @@
 #	define	UNUSED
 #endif
 
-#define DEBUG
 #ifdef DEBUG
 #	include <assert.h>
 #	define	ASSERT(expr)	do {if (!(expr)) {printf("%s:%s:%d - '%s' failed!\n", __FILE__, __FUNCTION__, __LINE__, #expr); abort();} }while(0)

--- a/dawg.c
+++ b/dawg.c
@@ -118,7 +118,7 @@ DAWG_add_word_unchecked(DAWG* dawg, String word) {
 	if (i < dawg->prev_word.length)
 		DAWG_replace_or_register(dawg, state, dawg->prev_word, i);
 
-	// 3. add sufix
+	// 3. add suffix
 	while (i < word.length) {
 		DAWGNode* new = dawgnode_new(word.chars[i]);
 		if (new == NULL)
@@ -129,7 +129,7 @@ DAWG_add_word_unchecked(DAWG* dawg, String word) {
 		dawgnode_set_child(state, word.chars[i], new);
 
 		if (item) {
-			memfree(item);
+			HASH_FREE(item);
 			resize_hash(&dawg->reg);
 			hashtable_add(&dawg->reg, state);
 		}
@@ -154,7 +154,7 @@ DAWG_add_word_unchecked(DAWG* dawg, String word) {
 
 	// save previous word
 	if (dawg->prev_word.chars)
-		free(dawg->prev_word.chars);
+		memfree(dawg->prev_word.chars);
 
 	dawg->prev_word.length	= word.length;
 	dawg->prev_word.chars	= (DAWG_LETTER_TYPE*)memalloc(word.length * DAWG_LETTER_SIZE);
@@ -244,7 +244,7 @@ DAWG_replace_or_register(DAWG* dawg, DAWGNode* state, String string, const size_
 				dawgnode_free(item->child);
 
 				if (prev) {
-					memfree(prev);
+					HASH_FREE(prev);
 					resize_hash(&dawg->reg);
 					hashtable_add(&dawg->reg, item->parent);
 				}
@@ -275,7 +275,7 @@ static bool PURE
 dawgnode_equivalence(DAWGNode* p, DAWGNode* q) {
 	/*
 		Both states p and q are equivalent (subtrees
-		rooted at p and q forms same languages):
+		rooted at p and q form same languages):
 
 		1. both are final/non-final
 		2. has same number of children
@@ -468,7 +468,7 @@ DAWG_traverse_DFS_once(DAWG* dawg, DAWG_traverse_callback callback, void* extra)
 	if (dawg->q0) {
 		if (dawg->visited_marker == 0) {
 			// counter wrapped, visited fields have to be cleared
-			puts("cleared");
+			//puts("cleared");
 			DAWG_traverse_clear_visited(dawg->q0);
 			dawg->visited_marker += 1;
 		}


### PR DESCRIPTION
* fixed memory deallocation bugs
   * use `memfree` macro in _DAWG_add_word_unchecked()_ for memory that was allocated with `memalloc` macro in _get_string()_
   * use `HASH_FREE` macro (defined as `free` in _dawg.h_) for memory that was allocated with `HASH_ALLOC` (using `malloc`) inside _hash/hashtable.c_
* fixed _DAWG_clear()_: can't use _DAWG_traverse_DFS_once()_ for memory free, since the same node could be reached more than once (and we could then be accessing a node that has already been freed)

These bugs caused segmentation faults in Python 3.6 (but apparently not in other Python versions)