### PR TITLE
Feature/new unicode api

### DIFF
--- a/pydawg.c
+++ b/pydawg.c
@@ -17,7 +17,7 @@
 #include "DAWG_class.h"
 #include "DAWGIterator_class.h"
 
-// c libary inlined
+// c library inlined
 #include "dawgnode.c"
 #include "dawg.c"
 
@@ -68,9 +68,9 @@ PyInit_pydawg(void) {
 #undef constant
 
 #ifdef DAWG_PERFECT_HASHING
-	PyModule_AddIntConstant(module, "perfect_hasing", 1);
+	PyModule_AddIntConstant(module, "perfect_hashing", 1);
 #else
-	PyModule_AddIntConstant(module, "perfect_hasing", 0);
+	PyModule_AddIntConstant(module, "perfect_hashing", 0);
 #endif
 
 #ifdef DAWG_UNICODE

--- a/pydawg.c
+++ b/pydawg.c
@@ -69,8 +69,10 @@ PyInit_pydawg(void) {
 
 #ifdef DAWG_PERFECT_HASHING
 	PyModule_AddIntConstant(module, "perfect_hashing", 1);
+	PyModule_AddIntConstant(module, "perfect_hasing", 1);
 #else
 	PyModule_AddIntConstant(module, "perfect_hashing", 0);
+	PyModule_AddIntConstant(module, "perfect_hasing", 0);
 #endif
 
 #ifdef DAWG_UNICODE

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,8 @@ module = Extension(
 	sources = ['pydawg.c'],
 	define_macros = [
 		('DAWG_PERFECT_HASHING', ''),	# enable perfect hashing
-		('DAWG_UNICODE', ''),			# use unicode
+		('DAWG_UNICODE', ''),		# use unicode
+		('DEBUG', ''),			# insert assertions
 	],
 	depends = [
 		'DAWG_class.c', 'DAWG_class.h',
@@ -35,7 +36,7 @@ module = Extension(
 
 setup(
 	name                = 'pyDAWG',
-    version             = '1.0.0',
+    version             = '1.0.1',
 	ext_modules         = [module],
 
     description         = "Directed Acyclic Word Graph (DAWG) allows to store huge strings set in compacted form",

--- a/unittests.py
+++ b/unittests.py
@@ -242,7 +242,7 @@ class TestPickle(TestDAWGBase):
 
 class TestMPH(TestDAWGBase):
 	def test_word2index(self):
-		if pydawg.perfect_hasing:
+		if pydawg.perfect_hashing:
 			D = self.D
 			# empty
 			for word in self.words:
@@ -271,7 +271,7 @@ class TestMPH(TestDAWGBase):
 
 
 	def test_index2word(self):
-		if pydawg.perfect_hasing:
+		if pydawg.perfect_hashing:
 			D = self.D
 
 			for i in range(-50, 50):

--- a/utils.c
+++ b/utils.c
@@ -12,11 +12,32 @@
 	$Id$
 */
 
+#if PY_VERSION_HEX >=  0x03030000
+# define NEW_UNICODE_API
+#endif
+
+#if (defined NEW_UNICODE_API && defined DAWG_UNICODE)
+#  define STRING_FREE(obj) 	PyMem_Free(obj)
+#  define STRING_RETURN_TYPE	DAWG_LETTER_TYPE
+#else
+#  define STRING_FREE(obj)	Py_DECREF(obj)
+#  define STRING_RETURN_TYPE	PyObject
+#endif
+
 
 /* returns bytes or unicode internal buffer */
-static PyObject*
+static STRING_RETURN_TYPE*
 pymod_get_string(PyObject* obj, DAWG_LETTER_TYPE** word, ssize_t* wordlen) {
-#ifdef DAWG_UNICODE
+#if (defined NEW_UNICODE_API && defined DAWG_UNICODE)
+	if (PyUnicode_READY(obj)) {
+		PyErr_SetString(PyExc_TypeError, "string expected");
+		return NULL;
+	}
+	//fprintf(stderr,"[KIND %d]",PyUnicode_KIND(obj));
+	//*wordlen = PyUnicode_GET_LENGTH(obj);
+	*word = (DAWG_LETTER_TYPE*)PyUnicode_AsWideCharString(obj, wordlen);
+	return *word;
+#elif defined DAWG_UNICODE
 	if (PyUnicode_Check(obj)) {
 		*word = (DAWG_LETTER_TYPE*)PyUnicode_AS_UNICODE(obj);
 		*wordlen = PyUnicode_GET_SIZE(obj);


### PR DESCRIPTION
* use the new Python Unicode API from PEP 393 for Python >= 3.3 and Unicode objects
* add `perfect_hashing` field to the object (keep the original `perfect_hasing` for backwards compatibility)
* `setup.py`:
  * defined DEBUG macro
  * version bumped to 1.0.1