### PR TITLE
Version 1.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2018-03-19 - version 1.2.0
+    * improved memory deallocation efficiency: first build the list of nodes using
+       DAWG_traverse_DFS_once() then deallocate them
+    * bugfix in dawg_mph.c: word2index() for a string that (a) is not a string
+	in the DAWG (b) is a prefix of an existing word and (c) contains a valid
+	word, should return None but returned the index of (c)
+    * fixes in Unicode conversion methods
+
 2017-11-26 - version 1.0.1
     * bug fixes on memory management
     * use of the new Unicode API for Python >= 3.3

--- a/DAWG_class.c
+++ b/DAWG_class.c
@@ -536,13 +536,18 @@ dump_aux(DAWGNode* node, UNUSED const size_t depth, void* extra) {
 	}
 
 	// 1.
-	tuple = Py_BuildValue("ii", node, (int)(node->eow));
+	tuple = Py_BuildValue("ni", node, (int)(node->eow));
 	append_tuple(Dump->nodes)
 
 	// 2.
 	for (i=0; i < node->n; i++) {
 		child = node->next[i].child;
-		tuple = Py_BuildValue("ici", node, node->next[i].letter, child);
+#ifdef DAWG_UNICODE
+		Py_UNICODE buf[2] = { node->next[i].letter, 0 };
+		tuple = Py_BuildValue("nun", node, buf, child);
+#else
+		tuple = Py_BuildValue("ncn", node, node->next[i].letter, child);
+#endif
 		append_tuple(Dump->edges)
 	}
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,37 @@
 .SUFFIXES:
 .PHONY: all build
 
+CC	:= gcc
+CFLAGS	:= -g -Wall -Wstrict-prototypes
+
+export CC
+export CFLAGS
+
+PYTHON := python3.5
+
 test: build
-	python3 unittests.py
+	$(PYTHON) unittests.py
 
 build:
-	python3 setup.py build_ext --inplace
+	echo $$CFLAGS
+	$(PYTHON) setup.py build_ext --inplace
 
 clean:
 	rm -f *.so
+
+sdist bdist:
+	$(PYTHON) setup.py $@
+
+
+# ----------------------------------------------------------------------
+
+VERSION := 1.2.0
+
+VENV_PATH ?= /opt/venv
+REPO_NAME ?= artifactory
+
+install: sdist
+	$(VENV_PATH)/pip install --upgrade dist/pyDAWG-$(VERSION).tar.gz
+
+upload: sdist
+	$(VENV_PATH)/bin/python setup.py sdist upload -r $(REPO_NAME)

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,10 @@
+This is a fork of the PyDAWG__ Python package, to try out changes and test bugfixes (bugfixes are contributed back to the original source). License is the same as the original package (3-clause BSD)
+
+__ https://github.com/WojciechMula/pyDAWG
+  
 ========================================================================
                                pyDAWG
 ========================================================================
-
-.. image:: https://travis-ci.org/WojciechMula/pyDAWG.svg?branch=master
-    :target: https://travis-ci.org/WojciechMula/pyDAWG
 
 .. contents::
 

--- a/common.h
+++ b/common.h
@@ -104,7 +104,13 @@ void *memcalloc(size_t nmemb, size_t size) {
 #   define memalloc PyMem_Malloc
 #   define memfree  PyMem_Free
 #   if PY_VERSION_HEX >=  0x03050000
-#   define memcalloc	PyMem_Calloc
+#     define memcalloc	PyMem_Calloc
+#   else
+      static inline void *memcalloc(size_t nmemb, size_t size) {
+	void *addr = memalloc(nmemb*size);
+	memset(addr, 0, nmemb*size);
+	return addr;
+      }
 #   endif
 #endif
 

--- a/dawg_mph.c
+++ b/dawg_mph.c
@@ -58,7 +58,7 @@ DAWG_mph_word2index(DAWG* dawg, const DAWG_LETTER_TYPE* word, const size_t wordl
 			return DAWG_NOT_EXISTS;
 	}
 
-	return index;
+	return state->eow ? index : DAWG_NOT_EXISTS;
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
 	name                = 'pyDAWG',
-    version             = '1.0.1',
+    version             = '1.2.0',
 	ext_modules         = [module],
 
     description         = "Directed Acyclic Word Graph (DAWG) allows to store huge strings set in compacted form",

--- a/unittests.py
+++ b/unittests.py
@@ -287,10 +287,18 @@ class TestMPH(TestDAWGBase):
 			self.assertEqual(min(S), 1)
 			self.assertEqual(max(S), len(D))
 
-			# inexising words
+			# unexisting words
 			index = D.word2index(conv("xyz"))
 			self.assertEqual(index, None)
 			index = D.word2index(conv(""))
+			self.assertEqual(index, None)
+
+			# Strings that are prefixes of existing words
+			# [1] a prefix not containing any valid word
+			index = D.word2index(conv("attrib"))
+			self.assertEqual(index, None)
+			# [2] a prefix that contains a valid word
+			index = D.word2index(conv("warb"))
 			self.assertEqual(index, None)
 
 

--- a/utils.c
+++ b/utils.c
@@ -35,7 +35,7 @@ pymod_get_string(PyObject* obj, DAWG_LETTER_TYPE** word, size_t* wordlen) {
 	}
 	//fprintf(stderr,"[KIND %d]",PyUnicode_KIND(obj));
 	//*wordlen = PyUnicode_GET_LENGTH(obj);
-	*word = (DAWG_LETTER_TYPE*)PyUnicode_AsWideCharString(obj, wordlen);
+	*word = (DAWG_LETTER_TYPE*)PyUnicode_AsWideCharString(obj, (ssize_t*)wordlen);
 	return *word;
 #elif defined DAWG_UNICODE
 	if (PyUnicode_Check(obj)) {


### PR DESCRIPTION
* improved memory deallocation: first build the list of nodes using `DAWG_traverse_DFS_once()` then deallocate them
* bugfix in dawg_mph.c: `word2index()` for a string that (a) is not a string in the DAWG (b) is a prefix of an existing word and (c) contains a valid word, should return `None` but returned the index of (c)
* fixes in Python value conversion (integer types) esp. for the version holding Unicode strings