### PR TITLE
version 1.2.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2019-04-10 - version 1.2.2
+    * fix: check valid object in pymod_get_string() to avoid segmentation
+      fault on bogus parameters
+
 2018-05-11 - version 1.2.1
     * merged latest version from upstream
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ module = Extension(
 
 setup(
 	name                = 'pyDAWG',
-    version             = '1.2.1',
+    version             = '1.2.2',
 	ext_modules         = [module],
 
     description         = "Directed Acyclic Word Graph (DAWG) allows to store huge strings set in compacted form",

--- a/utils.c
+++ b/utils.c
@@ -29,7 +29,7 @@
 static STRING_RETURN_TYPE*
 pymod_get_string(PyObject* obj, DAWG_LETTER_TYPE** word, size_t* wordlen) {
 #if (defined NEW_UNICODE_API && defined DAWG_UNICODE)
-	if (PyUnicode_READY(obj)) {
+	if (!PyUnicode_Check(obj) || PyUnicode_READY(obj)) {
 		PyErr_SetString(PyExc_TypeError, "string expected");
 		return NULL;
 	}


### PR DESCRIPTION
 * fix: check valid object in `pymod_get_string()` to avoid segmentation fault on bogus parameters