### PR TITLE
2020-10-13 - version 1.2.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+2020-10-13 - version 1.2.3
+    * fix: read README file in setup.py as UTF-8 to avoid installation error
+
 2019-04-10 - version 1.2.2
     * fix: check valid object in pymod_get_string() to avoid segmentation
       fault on bogus parameters

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,7 @@
 2020-10-13 - version 1.2.3
     * fix: read README file in setup.py as UTF-8 to avoid installation error
+    * use setuptools instead of distutils, this enables building wheel
+    * default Python is 3.6
 
 2019-04-10 - version 1.2.2
     * fix: check valid object in pymod_get_string() to avoid segmentation

--- a/DAWG_class.c
+++ b/DAWG_class.c
@@ -332,7 +332,7 @@ dawgmeth_find_all(PyObject* self, PyObject* args) {
 				default:
 					PyErr_SetString(PyExc_ValueError,
 						"third argument have to be one of MATCH_EXACT_LENGTH, "
-						"MATCH_AT_LEAST_PREFIX, MATCH_AT_LEAST_PREFIX"
+						"MATCH_AT_LEAST_PREFIX, MATCH_AT_MOST_PREFIX"
 					);
 					goto error;
 			}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS	:= -g -Wall -Wstrict-prototypes
 export CC
 export CFLAGS
 
-PYTHON := python3.5
+PYTHON ?= python3.6
 
 test: build
 	$(PYTHON) unittests.py
@@ -19,7 +19,7 @@ build:
 clean:
 	rm -f *.so
 
-sdist bdist:
+sdist bdist bdist_wheel:
 	$(PYTHON) setup.py $@
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,40 @@
 # -*- coding: utf-8 -*-
+import io
 from distutils.core import setup, Extension
 
 def get_readme():
-    with open('README.rst', 'rt') as f:
+    with io.open('README.rst', 'rt', encoding='utf-8') as f:
         body = f.read()
-
-        marker1 = '.. image'
-        marker2 = '.. contents'
-
+        #marker1 = '.. image'
+        #marker2 = '.. contents'
         #s = body.index(marker1)
         #e = body.index(marker2)
         #body = body[:s] + body[e:]
-
         return body
 
 
 module = Extension(
-	'pydawg',
-	sources = ['pydawg.c'],
-	define_macros = [
-		('DEBUG', 1),                   # define debug mode
-		('DAWG_PERFECT_HASHING', ''),	# enable perfect hashing
-		('DAWG_UNICODE', ''),		# use unicode
-	],
-	depends = [
-		'DAWG_class.c', 'DAWG_class.h',
-		'DAWGIterator_class.c', 'DAWGIterator_class.h',
-		'dawg.c', 'dawg.h', 'dawg_pickle.c', 'dawg_mph.c',
-		'dawgnode.c', 'dawgcode.h',
-		'slist.h', 'slist.c',
-		'utils.c',
-	]
+    'pydawg',
+    sources=['pydawg.c'],
+    define_macros=[
+        ('DEBUG', 1),                   # define debug mode
+        ('DAWG_PERFECT_HASHING', ''),   # enable perfect hashing
+        ('DAWG_UNICODE', ''),		# use unicode
+    ],
+    depends=[
+        'DAWG_class.c', 'DAWG_class.h',
+        'DAWGIterator_class.c', 'DAWGIterator_class.h',
+        'dawg.c', 'dawg.h', 'dawg_pickle.c', 'dawg_mph.c',
+        'dawgnode.c', 'dawgcode.h',
+        'slist.h', 'slist.c',
+        'utils.c',
+    ]
 )
 
 setup(
-	name                = 'pyDAWG',
-    version             = '1.2.2',
-	ext_modules         = [module],
-
+    name                = 'pyDAWG',
+    version             = '1.2.3',
+    ext_modules         = [module],
     description         = "Directed Acyclic Word Graph (DAWG) allows to store huge strings set in compacted form",
     author              = "Wojciech Muła",
     author_email        = "wojciech_mula@poczta.onet.pl",
@@ -52,7 +49,7 @@ setup(
         "graph",
         "dictionary",
     ],
-    classifiers      = [
+    classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: C",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import io
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 def get_readme():
     with io.open('README.rst', 'rt', encoding='utf-8') as f:
@@ -56,4 +56,5 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Text Editors :: Text Processing",
     ],
+    install_requires=['setuptools']
 )


### PR DESCRIPTION
 * fix: read README file in setup.py as UTF-8 to avoid installation error
 * use setuptools instead of distutils, this enables building wheel
 * default Python is 3.6

